### PR TITLE
Adding authentification with keycloak gatekeeper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,7 @@
             <artifactId>goodies-testsupport</artifactId>
             <scope>test</scope>
         </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/org/github/flytreeleft/nexus3/keycloak/plugin/internal/KeycloakHttpHeaderAuthToken.java
+++ b/src/main/java/org/github/flytreeleft/nexus3/keycloak/plugin/internal/KeycloakHttpHeaderAuthToken.java
@@ -2,6 +2,8 @@ package org.github.flytreeleft.nexus3.keycloak.plugin.internal;
 
 import org.sonatype.nexus.security.authc.HttpHeaderAuthenticationToken;
 
+import java.util.Map;
+
 /**
  * Authentication HTTP Header for Keycloak
  * <p/>
@@ -11,7 +13,12 @@ import org.sonatype.nexus.security.authc.HttpHeaderAuthenticationToken;
  * </pre>
  */
 public class KeycloakHttpHeaderAuthToken extends HttpHeaderAuthenticationToken {
+    //Headers used if Keycloak directly in front of Nexus
     public static final String HTTP_HEADER_NAME = "X-Keycloak-Sec-Auth";
+
+    //Headers used if Keycloak gatekeeper in front of Nexus
+    public static final String HTTP_HEADER_AUTH_TOKEN = "X-Auth-Token";
+    public static final String HTTP_HEADER_USERNAME = "X-Auth-Username";
 
     private String principal;
     private String credentials;
@@ -19,6 +26,15 @@ public class KeycloakHttpHeaderAuthToken extends HttpHeaderAuthenticationToken {
     public KeycloakHttpHeaderAuthToken(String headerName, String headerValue, String host) {
         super(headerName, headerValue, host);
 
+        this.updateCreedentials();
+    }
+
+    public KeycloakHttpHeaderAuthToken(Map<String, String> headers, String host) {
+        super(HTTP_HEADER_NAME, headers.get(HTTP_HEADER_USERNAME) + ":" + headers.get(HTTP_HEADER_AUTH_TOKEN), host);
+        this.updateCreedentials();
+    }
+
+    private void updateCreedentials(){
         String[] splits = super.getPrincipal().split(":");
         this.principal = splits.length > 0 ? splits[0] : null;
         this.credentials = splits.length > 1 ? splits[1] : "";

--- a/src/main/java/org/github/flytreeleft/nexus3/keycloak/plugin/internal/KeycloakHttpHeaderAuthTokenFactory.java
+++ b/src/main/java/org/github/flytreeleft/nexus3/keycloak/plugin/internal/KeycloakHttpHeaderAuthTokenFactory.java
@@ -1,10 +1,15 @@
 package org.github.flytreeleft.nexus3.keycloak.plugin.internal;
 
-import java.util.List;
+import java.util.*;
 import javax.inject.Named;
 import javax.inject.Singleton;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
 
 import com.google.common.collect.Lists;
+import org.apache.shiro.authc.AuthenticationToken;
+import org.apache.shiro.web.util.WebUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonatype.nexus.security.authc.HttpHeaderAuthenticationToken;
@@ -28,5 +33,38 @@ public class KeycloakHttpHeaderAuthTokenFactory extends HttpHeaderAuthentication
         HttpHeaderAuthenticationToken token = new KeycloakHttpHeaderAuthToken(headerName, headerValue, host);
 
         return token.getPrincipal() != null ? token : null;
+    }
+
+    @Override
+    public AuthenticationToken createToken(ServletRequest request, ServletResponse response) {
+        HttpServletRequest httpRequest = WebUtils.toHttp(request);
+
+        //First, check if X-Keycloak-Sec-Auth is present.
+        List<String> headerNames = this.getHttpHeaderNames();
+        if (headerNames != null) {
+            Iterator var6 = headerNames.iterator();
+
+            while(var6.hasNext()) {
+                String headerName = (String)var6.next();
+                String headerValue = httpRequest.getHeader(headerName);
+                if (headerValue != null) {
+                    // if X-Keycloak-Sec-Auth is present, use this header to generate the token
+                    return this.createToken( headerName,  headerValue, request.getRemoteHost());
+                }
+            }
+        }
+        //If X-Keycloak-Sec-Auth not present, may be behind gatekeeper
+        // So we use Authorization and X-Auth-Username headers to fill the X-Keycloak-Sec-Auth header
+        String headerAuthTokenValue = httpRequest.getHeader(KeycloakHttpHeaderAuthToken.HTTP_HEADER_AUTH_TOKEN);
+        String headerUsernameValue = httpRequest.getHeader(KeycloakHttpHeaderAuthToken.HTTP_HEADER_USERNAME);
+        if (headerAuthTokenValue != null && headerUsernameValue != null) {
+            Map<String, String> headers = new HashMap<>();
+            headers.put(KeycloakHttpHeaderAuthToken.HTTP_HEADER_AUTH_TOKEN, headerAuthTokenValue);
+            headers.put(KeycloakHttpHeaderAuthToken.HTTP_HEADER_USERNAME, headerUsernameValue);
+            HttpHeaderAuthenticationToken token = new KeycloakHttpHeaderAuthToken(headers, request.getRemoteHost());
+            return token.getPrincipal() != null ? token : null;
+        }
+
+        return null;
     }
 }

--- a/src/main/java/org/github/flytreeleft/nexus3/keycloak/plugin/internal/NexusKeycloakClient.java
+++ b/src/main/java/org/github/flytreeleft/nexus3/keycloak/plugin/internal/NexusKeycloakClient.java
@@ -23,7 +23,6 @@ import org.sonatype.nexus.security.user.User;
 import org.sonatype.nexus.security.user.UserSearchCriteria;
 
 public class NexusKeycloakClient {
-    private static final Logger logger = LoggerFactory.getLogger(NexusKeycloakClient.class);
 
     private String source;
     private String sourceCode;
@@ -66,8 +65,8 @@ public class NexusKeycloakClient {
     public boolean authenticate(KeycloakHttpHeaderAuthToken token) {
         String principal = token.getPrincipal();
         String credentials = token.getCredentials().toString();
-
         UserInfo userInfo = this.keycloakAdminClient.obtainUserInfo(credentials);
+
         if (userInfo == null) {
             return false;
         }


### PR DESCRIPTION
**Need**: Authentication with keycloak Gatekeeper.

Headers sent by gatekeeper to identify the user are X-Auth-Token and X-Auth-Username.
We use these headers to re-assign the value of X-Keycloak-Sec-Auth header.

**Behaviour**:

The header X-Keycloak-Sec-Auth is first checked. If present, we have the same behaviour than before.
If not present, we checked if headers X-Auth-Token and X-Auth-Username are present.

We needed this quickly enough to our developments. Therefore, there are some part of code that could be configurable (trusted connexion as we use auto-sign certificate).

Thx !