### PR TITLE
Avoid double slashes in URL

### DIFF
--- a/src/main/java/org/github/flytreeleft/nexus3/keycloak/plugin/internal/http/Http.java
+++ b/src/main/java/org/github/flytreeleft/nexus3/keycloak/plugin/internal/http/Http.java
@@ -50,7 +50,11 @@ public class Http {
     }
 
     private URI uri(String path, Object... placeholders) {
-        return URI.create(this.config.getAuthServerUrl() + String.format(path, placeholders));
+        String authServerUrl = this.config.getAuthServerUrl();
+        if (authServerUrl.endsWith("/") && path.startsWith("/")) {
+            authServerUrl = authServerUrl.substring(0, authServerUrl.length()-1 );
+        }
+        return URI.create(authServerUrl + String.format(path, placeholders));
     }
 
     private <R> HttpMethod<R> method(RequestBuilder builder) {


### PR DESCRIPTION
Keycloak generates the auth-server-url with a trailing slash in newer versions, which leads to URIs with double slashes.

Since the requests results in an error, we get Null responses as described in #34 

This pull request just makes sure to remove double slashes when concatenating auth-server-url with the path.

Fixes #34