### PR TITLE
Nexus plugin dependency update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.sonatype.nexus.plugins</groupId>
         <artifactId>nexus-plugins</artifactId>
-        <version>3.6.0-02</version>
+        <version>3.15.3-01</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
Starting from Nexus 3.15 a new bundle format is supported, without the need to add it to startup.properties.
https://help.sonatype.com/repomanager3/bundle-development/installing-bundles
```
mvn -PbuildKar clean install
```

To be able to package the plugin in this new format the nexus-plugins dependency needs to be updated to 3.15+